### PR TITLE
Fixed parameter typo in Al.Graphics.cs

### DIFF
--- a/Source/AllegroDotNet/Al.Graphics.cs
+++ b/Source/AllegroDotNet/Al.Graphics.cs
@@ -395,7 +395,7 @@ public static partial class Al
     float dh,
     FlipFlags flags)
   {
-    Interop.Core.AlDrawTintedScaledBitmap(NativePointer.Get(bitmap), tint, sx, sy, sw, sh, dx, dy, sw, dh, (int)flags);
+    Interop.Core.AlDrawTintedScaledBitmap(NativePointer.Get(bitmap), tint, sx, sy, sw, sh, dx, dy, dw, dh, (int)flags);
   }
 
   public static AllegroBitmap? GetTargetBitmap()

--- a/Source/AllegroDotNet/Al.Joystick.cs
+++ b/Source/AllegroDotNet/Al.Joystick.cs
@@ -94,7 +94,7 @@ public static partial class Al
     return Interop.Core.AlGetJoystickNumButtons(NativePointer.Get(joystick));
   }
 
-  public static void GetJoystickState(AllegroJoystick? joystick, AllegroJoystickState state)
+  public static void GetJoystickState(AllegroJoystick? joystick, ref AllegroJoystickState state)
   {
     Interop.Core.AlGetJoystickState(NativePointer.Get(joystick), ref state);
   }


### PR DESCRIPTION
Wrong parameter was specified in Al.DrawScaledBitmap()